### PR TITLE
Error checking for empty event-type 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6139,8 +6139,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6158,13 +6157,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6177,18 +6174,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6291,8 +6285,7 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6302,7 +6295,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6315,20 +6307,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6345,7 +6334,6 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -6401,8 +6389,7 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -6427,8 +6414,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6438,7 +6424,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6507,8 +6492,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6538,7 +6522,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6556,7 +6539,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6595,13 +6577,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/components/CalendarGrid/GetCalendarGrid.js
+++ b/src/components/CalendarGrid/GetCalendarGrid.js
@@ -189,7 +189,12 @@ class GetCalendarGrid extends React.Component {
           console.log(imageUrl)
         }
 
-        var thisclass = element.fields.EventType[0];
+      if(element.fields.EventType == undefined) {
+          var thisclass = "";
+      } else  {
+          var thisclass = element.fields.EventType[0];
+      }
+
         console.log(element.fields)
 
          eventDays.push(


### PR DESCRIPTION
If Event Type isn't present in the Airtable, it checks for that and doesn't assign a CSS class to those events